### PR TITLE
add issue notification types

### DIFF
--- a/templates/notify.jinja
+++ b/templates/notify.jinja
@@ -3,7 +3,11 @@
 {# notification_type can be
   MEDIA_PENDING (new request),
   MEDIA_DECLINED, MEDIA_APPROVED,
-  MEDIA_AVAILABLE (completed)
+  MEDIA_AVAILABLE (completed),
+  ISSUE_CREATED, (new issue)
+  ISSUE_REOPENED,
+  ISSUE_RESOLVED,
+  ISSUE_COMMENT, 
 #}
 {% if notification_type == "MEDIA_PENDING" %}
 New {{ media.media_type }} request from {{ request.requestedBy_username }}:
@@ -17,6 +21,18 @@ Type "/r pending" here to approve, decline, or edit this request
   Request for {{ subject }} approved
 {% elif notification_type == "MEDIA_AVAILABLE" -%}
   {{ subject }} is now ready to watch
+{# even if an issue is "closed with comment", they will be separate notification events
+   issue notif will have "subject" var, which is generally the movie/tv title
+#}
+{% elif notification_type in ("ISSUE_CREATED", "ISSUE_REOPENED") -%}
+  Issue {{ issue.issue_id }} opened for {{ subject }} by {{ issue.reportedBy_username }}
+  {% if api %}{{ api.make_abs_url("/issue/") }}{{ issue.issue_id }}{% endif %}
+{% elif notification_type == "ISSUE_COMMENT" -%}
+  {{ comment.commentedBy_username }} commented on '{{ subject }}' issue:
+  {{ comment.comment_message}}
+{% elif notification_type == "ISSUE_RESOLVED" -%}
+  Issue {{ issue.issue_id }} closed for {{ subject }}
 {% elif notification_type == "TEST_NOTIFICATION" -%}
   {{ message }}
 {% endif %}
+


### PR DESCRIPTION
Adds some more messages for the notify template to handle 'issue' notification types from overseerr.

https://docs.overseerr.dev/using-overseerr/notifications/webhooks#issue

i've already updated the overseerr notification payload to include:

```
    "{{issue}}": {
        "issue_id": "{{issue_id}}",
        "reportedBy_username" : "{{reportedBy_username}}"
    },
    "{{comment}}": {
        "comment": "{{comment_message}}",
        "commentedBy_username": "{{commentedBy_username}}"
    }
```

Note: 'comments' are fired as a separate notification events (afaict), even if the user performs an action like "close" with a comment included.

Test plan: not sure how to really test this end-to-end. I did check the rendered output in interactive python interpreter, e.g.:

```
>>> context['notification_type'] = "ISSUE_CREATED"
>>> print(jinja2.Environment(loader=jinja2.FileSystemLoader(".")).get_template("notify.jinja").render(context))

Issue 4 opened for test subject by martin avalon

>>> context['notification_type'] = "ISSUE_COMMENT"
>>> print(jinja2.Environment(loader=jinja2.FileSystemLoader(".")).get_template("notify.jinja").render(context))

ken v commented on 'test subject' issue:
  test comment

>>> context['notification_type'] = "ISSUE_RESOLVED"
>>> print(jinja2.Environment(loader=jinja2.FileSystemLoader(".")).get_template("notify.jinja").render(context))

Issue 4 closed for test subject

>>> context['notification_type'] = "ISSUE_REOPENED"
>>> print(jinja2.Environment(loader=jinja2.FileSystemLoader(".")).get_template("notify.jinja").render(context))
Issue 4 opened for test subject by martin avalon
```